### PR TITLE
Remove trailing comma that fools Ruby 1.8 parser

### DIFF
--- a/providers/apt_repository.rb
+++ b/providers/apt_repository.rb
@@ -27,7 +27,7 @@ action :add do
     mode "0644"
     variables(
       :name => name,
-      :config => new_resource.config.gsub(/^ */,''),
+      :config => new_resource.config.gsub(/^ */,'')
     )
     cookbook "sys"
     notifies :run, "execute[#{apt_update}]", :immediately


### PR DESCRIPTION
I'm trying to use this on my Debian Squeeze boxes configured with default APT Ruby 1.8.7 and this single comma crashes the parser thus it would be nice if you would merge this :)
